### PR TITLE
S3 fixes

### DIFF
--- a/config.mk.in
+++ b/config.mk.in
@@ -83,7 +83,7 @@ plugin_OBJS += hfile_s3_write.o
 
 CRYPTO_LIBS = @CRYPTO_LIBS@
 noplugin_LIBS += $(CRYPTO_LIBS)
-hfile_s3$(PLUGIN_EXT): LIBS += $(CRYPTO_LIBS)
+hfile_s3$(PLUGIN_EXT): LIBS += $(CRYPTO_LIBS) $(LIBCURL_LIBS)
 hfile_s3_write$(PLUGIN_EXT): LIBS += $(CRYPTO_LIBS) $(LIBCURL_LIBS)
 endif
 

--- a/hfile_s3.c
+++ b/hfile_s3.c
@@ -2442,6 +2442,8 @@ static hFILE *s3_open_v4(const char *s3url, const char *mode, va_list *argsp) {
     }
 
     ks_free(&url);
+    if (!fp)
+        free_auth_data(ad);
 
     return fp;
 }
@@ -2465,6 +2467,8 @@ static hFILE *s3_open_v2(const char *s3url, const char *mode, va_list *argsp) {
     }
 
     ks_free(&url);
+    if (!fp)
+        free_auth_data(ad);
 
     return fp;
 }

--- a/hfile_s3.c
+++ b/hfile_s3.c
@@ -98,7 +98,7 @@ typedef struct {
     // read variables
     size_t last_read;               // last read position (remote)
     size_t last_read_buffer;        // last read (local buffer)
-    size_t file_size;               // size of the file being read
+    int64_t file_size;              // size of the file being read
     int keep_going;
 
 } hFILE_s3;


### PR DESCRIPTION
* `file_size` needs to be signed as it can be set to -1 and compared `< 0`.
* Add missing `-lcurl` to `hfile_s3` plug-in link.  Now needed as it uses libcurl directly.
* Fix a memory leak when failing to open a file.